### PR TITLE
feat: add query param handling

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -93,13 +93,12 @@ export class Client extends BaseClient {
     );
   }
 
-  getRoundMatchingFunds(roundId: string, overrides?: Blob): Promise<Match[]> {
+  getRoundMatchingFunds(roundId: string,  params?: any, overrides?: Blob): Promise<Match[]> {
     let fetchOptions = undefined;
 
     if (overrides) {
       const body = new FormData();
       body.set("overrides", overrides);
-
       fetchOptions = {
         method: "POST",
         body,
@@ -108,7 +107,7 @@ export class Client extends BaseClient {
 
     return this.fetchResources(
       "roundMatchingFunds",
-      { roundId },
+      { roundId, ...params },
       roundMatchBuilder,
       fetchOptions,
     );


### PR DESCRIPTION
adds query param handling to the baseclient and implements that on `getRoundMatchingFunds` necessary for https://github.com/gitcoinco/grants-stack/pull/1706