### PR TITLE
Fix bin file destination in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/client/index.js",
   "types": "dist/client/index.d.ts",
-  "bin": "dist/cli/index.ts",
+  "bin": "dist/cli/index.js",
   "prettier": {
     "trailingComma": "all"
   },


### PR DESCRIPTION
the bin field for directly running the indexer cli has the correct .js extension now